### PR TITLE
auto calculate average weight on general stat

### DIFF
--- a/app/models/exercise_session.rb
+++ b/app/models/exercise_session.rb
@@ -1,3 +1,4 @@
 class ExerciseSession < ApplicationRecord
   belongs_to :user
+  has_many :weight_sets
 end

--- a/app/models/general_stat.rb
+++ b/app/models/general_stat.rb
@@ -3,18 +3,17 @@ class GeneralStat < ApplicationRecord
 
   before_save :calculate_average_weight
 
-  DEFAULT_LIMIT = 7
+  LIMIT = 7
 
-  def calculate_average_weight(limit = DEFAULT_LIMIT)
-    @limit = limit
-    self.weight_avg = (total_weight / limit).round(2)
+  def calculate_average_weight
+    self.weight_avg = (total_weight / LIMIT).round(2)
   end
 
 private
 
 # inject is used to add together items in an array
   def total_weight
-    self.class.previous_stats(@limit, date).inject(0) do |total, stat|
+    self.class.previous_stats(date).inject(0) do |total, stat|
       total + stat.weight.to_f
     end
   end
@@ -24,7 +23,7 @@ private
     # SELECT  "general_stats"."weight" FROM "general_stats"
     # WHERE (date < '2017-09-09 00:00:00')
     # ORDER BY "general_stats"."date" DESC LIMIT $1  [["LIMIT", 6]]
-  def self.previous_stats(limit, date = DateTime.now)
-    where("date < ?", date).select(:weight).limit(limit).order(date: :desc)
+  def self.previous_stats(date)
+    where("date < ?", date).select(:weight).limit(LIMIT).order(date: :desc)
   end
 end

--- a/app/models/general_stat.rb
+++ b/app/models/general_stat.rb
@@ -1,6 +1,10 @@
 class GeneralStat < ApplicationRecord
   belongs_to :user
 
+  validates_presence_of :date
+  validates_presence_of :weight
+  validates_presence_of :user_id
+
   before_save :calculate_average_weight
 
   LIMIT = 7

--- a/app/models/general_stat.rb
+++ b/app/models/general_stat.rb
@@ -6,7 +6,7 @@ class GeneralStat < ApplicationRecord
   DEFAULT_LIMIT = 7
 
   def calculate_average_weight(limit = DEFAULT_LIMIT)
-    @limit = limit - 1
+    @limit = limit
     self.weight_avg = (total_weight / limit).round(2)
   end
 
@@ -16,7 +16,7 @@ private
   def total_weight
     self.class.previous_stats(@limit, date).inject(0) do |total, stat|
       total + stat.weight.to_f
-    end + weight.to_f
+    end
   end
 
   # fetches the last limit items from before the current item's date

--- a/app/models/general_stat.rb
+++ b/app/models/general_stat.rb
@@ -1,3 +1,24 @@
 class GeneralStat < ApplicationRecord
   belongs_to :user
+
+  before_save :calculate_average_weight
+
+  DEFAULT_LIMIT = 7
+
+  def calculate_average_weight(limit = DEFAULT_LIMIT)
+    @limit = limit - 1
+    self.weight_avg = (total_weight / limit).round(2)
+  end
+
+private
+
+  def total_weight
+    self.class.last_number_stats(@limit, date).inject(0) do |total, stat|
+      total + stat.weight.to_f
+    end + weight.to_f
+  end
+
+  def self.last_number_stats(limit, date = DateTime.now)
+    where("date < ?", date).select(:weight).limit(limit).order(date: :desc)
+  end
 end

--- a/app/models/general_stat.rb
+++ b/app/models/general_stat.rb
@@ -21,7 +21,7 @@ private
 
   # fetches the last limit items from before the current item's date
   # generates the following sql:
-    # SELECT  "general_stats"."date", "general_stats"."weight" FROM "general_stats"
+    # SELECT  "general_stats"."weight" FROM "general_stats"
     # WHERE (date < '2017-09-09 00:00:00')
     # ORDER BY "general_stats"."date" DESC LIMIT $1  [["LIMIT", 6]]
   def self.previous_stats(limit, date = DateTime.now)

--- a/app/models/general_stat.rb
+++ b/app/models/general_stat.rb
@@ -13,12 +13,12 @@ class GeneralStat < ApplicationRecord
 private
 
   def total_weight
-    self.class.last_number_stats(@limit, date).inject(0) do |total, stat|
+    self.class.previous_stats(@limit, date).inject(0) do |total, stat|
       total + stat.weight.to_f
     end + weight.to_f
   end
 
-  def self.last_number_stats(limit, date = DateTime.now)
+  def self.previous_stats(limit, date = DateTime.now)
     where("date < ?", date).select(:weight).limit(limit).order(date: :desc)
   end
 end

--- a/app/models/general_stat.rb
+++ b/app/models/general_stat.rb
@@ -12,12 +12,18 @@ class GeneralStat < ApplicationRecord
 
 private
 
+# inject is used to add together items in an array
   def total_weight
     self.class.previous_stats(@limit, date).inject(0) do |total, stat|
       total + stat.weight.to_f
     end + weight.to_f
   end
 
+  # fetches the last limit items from before the current item's date
+  # generates the following sql:
+    # SELECT  "general_stats"."date", "general_stats"."weight" FROM "general_stats"
+    # WHERE (date < '2017-09-09 00:00:00')
+    # ORDER BY "general_stats"."date" DESC LIMIT $1  [["LIMIT", 6]]
   def self.previous_stats(limit, date = DateTime.now)
     where("date < ?", date).select(:weight).limit(limit).order(date: :desc)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  has_many :general_stats
+  has_many :exercise_sessions
+  has_many :weight_sets #, through: :exercise_sessions
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,5 @@ class User < ApplicationRecord
 
   has_many :general_stats
   has_many :exercise_sessions
-  has_many :weight_sets #, through: :exercise_sessions
+  has_many :weight_sets, through: :exercise_sessions
 end

--- a/app/models/weight_set.rb
+++ b/app/models/weight_set.rb
@@ -1,3 +1,4 @@
 class WeightSet < ApplicationRecord
-  belongs_to :user
+  belongs_to :user #it should not though
+  belongs_to :exercise_session
 end

--- a/app/models/weight_set.rb
+++ b/app/models/weight_set.rb
@@ -1,4 +1,4 @@
 class WeightSet < ApplicationRecord
-  belongs_to :user #it should not though
   belongs_to :exercise_session
+  delegate :user, to: :exercise_session
 end

--- a/app/views/general_stats/_form.html.erb
+++ b/app/views/general_stats/_form.html.erb
@@ -22,15 +22,9 @@
   </div>
 
   <div class="field">
-    <%= form.label :weight_avg %>
-    <%= form.text_field :weight_avg, id: :general_stat_weight_avg %>
-  </div>
-
-  <div class="field">
     <%= form.label :cal %>
     <%= form.text_field :cal, id: :general_stat_cal %>
   </div>
-
 
   <div class="actions">
     <%= form.submit %>

--- a/db/migrate/20171022191328_create_exercise_sessions.rb
+++ b/db/migrate/20171022191328_create_exercise_sessions.rb
@@ -1,9 +1,9 @@
 class CreateExerciseSessions < ActiveRecord::Migration[5.1]
   def change
     create_table :exercise_sessions do |t|
-      t.datetime :date
-      t.string :type_name
-      t.string :program
+      t.datetime :date, null: false
+      t.string :type_name, null: false
+      t.string :program, null: false
       t.references :user, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20171022191549_create_weight_sets.rb
+++ b/db/migrate/20171022191549_create_weight_sets.rb
@@ -4,7 +4,6 @@ class CreateWeightSets < ActiveRecord::Migration[5.1]
       t.string :weight, null: false
       t.string :reps, null: false
       t.references :exercise_session, foreign_key: true
-      t.references :user, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20171022191549_create_weight_sets.rb
+++ b/db/migrate/20171022191549_create_weight_sets.rb
@@ -1,9 +1,9 @@
 class CreateWeightSets < ActiveRecord::Migration[5.1]
   def change
     create_table :weight_sets do |t|
-      t.string :weight
-      t.string :reps
-      t.references :exercise_session
+      t.string :weight, null: false
+      t.string :reps, null: false
+      t.references :exercise_session, foreign_key: true
       t.references :user, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20171022191817_create_general_stats.rb
+++ b/db/migrate/20171022191817_create_general_stats.rb
@@ -1,10 +1,10 @@
 class CreateGeneralStats < ActiveRecord::Migration[5.1]
   def change
     create_table :general_stats do |t|
-      t.datetime :date
-      t.string :weight
+      t.datetime :date, null: false
+      t.string :weight, null: false
       t.string :weight_avg
-      t.string :cal
+      t.string :cal, null: false
       t.references :user, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,15 +57,12 @@ ActiveRecord::Schema.define(version: 20171022191817) do
     t.string "weight", null: false
     t.string "reps", null: false
     t.bigint "exercise_session_id"
-    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exercise_session_id"], name: "index_weight_sets_on_exercise_session_id"
-    t.index ["user_id"], name: "index_weight_sets_on_user_id"
   end
 
   add_foreign_key "exercise_sessions", "users"
   add_foreign_key "general_stats", "users"
   add_foreign_key "weight_sets", "exercise_sessions"
-  add_foreign_key "weight_sets", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,9 +16,9 @@ ActiveRecord::Schema.define(version: 20171022191817) do
   enable_extension "plpgsql"
 
   create_table "exercise_sessions", force: :cascade do |t|
-    t.datetime "date"
-    t.string "type_name"
-    t.string "program"
+    t.datetime "date", null: false
+    t.string "type_name", null: false
+    t.string "program", null: false
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -26,10 +26,10 @@ ActiveRecord::Schema.define(version: 20171022191817) do
   end
 
   create_table "general_stats", force: :cascade do |t|
-    t.datetime "date"
-    t.string "weight"
+    t.datetime "date", null: false
+    t.string "weight", null: false
     t.string "weight_avg"
-    t.string "cal"
+    t.string "cal", null: false
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -54,8 +54,8 @@ ActiveRecord::Schema.define(version: 20171022191817) do
   end
 
   create_table "weight_sets", force: :cascade do |t|
-    t.string "weight"
-    t.string "reps"
+    t.string "weight", null: false
+    t.string "reps", null: false
     t.bigint "exercise_session_id"
     t.bigint "user_id"
     t.datetime "created_at", null: false
@@ -66,5 +66,6 @@ ActiveRecord::Schema.define(version: 20171022191817) do
 
   add_foreign_key "exercise_sessions", "users"
   add_foreign_key "general_stats", "users"
+  add_foreign_key "weight_sets", "exercise_sessions"
   add_foreign_key "weight_sets", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,6 +35,7 @@ csv_with_class_names.each do |class_name, csv_file|
   csv.each do |row|
     data = row.to_h
     data['date'] = Date.strptime(data['date'], "%m/%d/%Y") if data['date']
+    data.delete('user_id') if csv_file == "weight_set.csv"
     class_name.find_or_create_by(data)
   end
 


### PR DESCRIPTION
Let's chat about this before merging it.

This PR does several things:
1) It removes the option to add weight to general stats.  It does this by removing the option from the form file.
2) It adds several methods onto the GeneralStat model, which calculate the average weight of the previous six stats plus the current stat, and auto fills in the weight_avg column.  This method automatically triggers when you call .save on the model.
3) Adds some model associations via has_many and belongs_to, which are common in rails, but we haven't really talked about yet.